### PR TITLE
add ability to use non-"public" schema

### DIFF
--- a/src/Models/DB.php
+++ b/src/Models/DB.php
@@ -37,7 +37,7 @@ class DB extends Manager
             'collation' => $config::get('Database')->default['DBCollat'], 
             'prefix'    => $config::get('Database')->default['DBPrefix'],
             'strict'    => $config::get('Database')->default['strictOn'],
-            'schema'    => 'public',
+            'schema'    => config('Database')->connect()->schema ?? 'public'
         ]);
 
         $capsule->setAsGlobal();


### PR DESCRIPTION
For postgres, it requires https://github.com/agungsugiarto/codeigniter4-eloquent/pull/2 to be merged first.

Step to reproduce:

```php
<?php namespace App\Controllers;

use App\Models\Album;
use Fluent\Models\DB;

class Home extends BaseController
{
	public function index()
	{
		config('Database')->connect()->schema  = 'abcdef';

		service('eloquent');

		return $this->response->setJSON([
			'data'   => Album::all(),
			'sample' => DB::table('album')->skip(1)->take(100)->get(),
		]);
	}
}
```