### PR TITLE
Bug Fix : postgre driver name with lower case

### DIFF
--- a/src/Models/DB.php
+++ b/src/Models/DB.php
@@ -16,7 +16,7 @@ class DB extends Manager
             case 'MySQLi':
                 $this->driver = 'mysql';
                 break;
-            case 'Postgre':
+            case 'postgre':
                 $this->driver = 'pgsql';
                 break;
             case 'SQLite3':


### PR DESCRIPTION
for postgresql, driver name in CI4 is named "postgre" instead of "Postgre"