### PR TITLE
[Driver] Register SQLSRV driver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "codeigniter4/framework": "^4.0",
+        "codeigniter4/framework": "^4.0.5",
         "illuminate/database": "^7.25",
         "illuminate/pagination": "^7.25"
     },

--- a/src/Models/DB.php
+++ b/src/Models/DB.php
@@ -26,6 +26,9 @@ class DB extends Manager
             case 'SQLite3':
                 $this->driver = 'sqlite';
                 break;
+            case 'SQLSRV':
+                $this->driver = 'sqlsrv';
+                break;
             default:
                 $this->driver = 'mysql';
                 break;


### PR DESCRIPTION
`SQLSRV` driver exists since CodeIgniter 4.0.5, This PR add `SQLSRV` driver and update requirement to `^4.0.5`

